### PR TITLE
Add license to NuGet package

### DIFF
--- a/mcs/class/Mono.Security/Install/WiX2/Source Files/Export/RedGate.ThirdParty.Mono.Security.wxs
+++ b/mcs/class/Mono.Security/Install/WiX2/Source Files/Export/RedGate.ThirdParty.Mono.Security.wxs
@@ -1,0 +1,14 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
+  <Fragment Id="MonoSec">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="MonoSec" Guid="{9489042B-5008-4AD0-89B7-76D9409288B8}" DiskId="1">
+        <File Id="Mono.Security.dll" Name="MonoSec.dll" LongName="Mono.Security.dll" Source="..\Files\Mono.Security.dll" />
+        <File Id="Monolic" Name="Monolic.txt" LongName="Mono.Security.license.txt" Source="..\Files\Mono.Security.license.txt" />
+      </Component>
+    </DirectoryRef>
+
+    <FeatureRef Id="Product">
+      <ComponentRef Id="MonoSec"/>
+    </FeatureRef>
+  </Fragment>
+</Wix>

--- a/mcs/class/Mono.Security/LICENSE
+++ b/mcs/class/Mono.Security/LICENSE
@@ -1,0 +1,25 @@
+The MIT X11 License covers most of the class libraries in the Mono
+project.  Some third party libraries come from different projects, and
+are licensed under their own terms.
+
+
+Copyright (c) 2001, 2002, 2003 The Mono Project
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
+++ b/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
@@ -16,5 +16,6 @@
 		<file src="Build\Mono.Security.dll" target="lib" />
 		<file src="Build\Mono.Security.pdb" target="lib" />
 		<file src="LICENSE" target="App_Readme\Mono.Security.license.txt" />
+		<file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.Mono.Security.wxs" target="wix2" />
 	</files>
 </package>

--- a/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
+++ b/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
@@ -15,5 +15,6 @@
 	<files>
 		<file src="Build\Mono.Security.dll" target="lib" />
 		<file src="Build\Mono.Security.pdb" target="lib" />
+		<file src="LICENSE" target="App_Readme\Mono.Security.license.txt" />
 	</files>
 </package>


### PR DESCRIPTION
This adds the license to the Mono.Security NuGet package. I've also copied the license from the mcs\class directory into the mcs\class\Mono.Security directory because it's the simplest way for us to have the license available on the build server (see commit message https://github.com/red-gate/mono/commit/53a9a19efb7592f78aec5ce31793d5d5e1fcf15e)

I've also moved the installer fragment into here (it previously lived in NGit)
