### PR TITLE
Added a special .targets file in the nuget package build/ folder.

### DIFF
--- a/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
+++ b/mcs/class/Mono.Security/Nuspec/Mono.Security.nuspec
@@ -13,6 +13,7 @@
 		<projectUrl>https://github.com/red-gate/mono</projectUrl>
 	</metadata>
 	<files>
+		<file src="Nuspec\RedGate.ThirdParty.Mono.Security.targets" target="build" />
 		<file src="Build\Mono.Security.dll" target="lib" />
 		<file src="Build\Mono.Security.pdb" target="lib" />
 		<file src="LICENSE.md" target="App_Readme\Mono.Security.license.md" />

--- a/mcs/class/Mono.Security/Nuspec/RedGate.ThirdParty.Mono.Security.targets
+++ b/mcs/class/Mono.Security/Nuspec/RedGate.ThirdParty.Mono.Security.targets
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Add the license files of the nuget package as linked items in the project file.
+    + get them to be copied to the build output folder.
+    -->
+    <None Include="$(MSBuildThisFileDirectory)..\App_Readme\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This .targets file is responsible for copying the license files to the build output folder.

This means we won't have to use custom post build events in projects referencing
the RedGate.ThirdParty.Mono.Security package
